### PR TITLE
Upgrade babel-loader to support webpack3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "babel-core": "^6.21.0",
     "babel-eslint": "^7.1.1",
-    "babel-loader": "^6.2.4",
+    "babel-loader": "^7.1.2",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
@@ -69,6 +69,6 @@
     "webpack-stream": "^3.2.0"
   },
   "dependencies": {
-    "babel-loader": "^6.2.4"
+    "babel-loader": "^7.1.2"
   }
 }


### PR DESCRIPTION
review me pls @sandersbrad 

This isn't upgraded in the upstream version sadly. But I'm tired of seeing this warning message. I don't expect this breaks anything but who knows.

I tried merging upstream but there were a ton of conflicts so I'm not going to bother. Let's remove this dependency ASAP.