### PR TITLE
Consider startAtStep when constructing component

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -31,11 +31,11 @@ var StepZilla = function (_Component) {
     var _this = _possibleConstructorReturn(this, (StepZilla.__proto__ || Object.getPrototypeOf(StepZilla)).call(this, props));
 
     _this.state = {
-      showPreviousBtn: false,
+      showPreviousBtn: _this.shouldShowPrevBtnOnStart(),
       showNextBtn: true,
       compState: _this.props.startAtStep,
       navState: _this.getNavStates(0, _this.props.steps.length),
-      nextStepText: 'Next'
+      nextStepText: _this.initialNextBtnText()
     };
 
     _this.hidden = {
@@ -50,6 +50,22 @@ var StepZilla = function (_Component) {
   }
 
   _createClass(StepZilla, [{
+    key: 'shouldShowPrevBtnOnStart',
+    value: function shouldShowPrevBtnOnStart() {
+      return !!this.props.startAtStep && this.props.startAtStep > 0;
+    }
+  }, {
+    key: 'initialNextBtnText',
+    value: function initialNextBtnText() {
+      var initialNextText = 'Next';
+
+      if (this.props.startAtStep === this.props.steps.length - 1 && !!this.props.nextTextOnLastStep) {
+        initialNextText = this.props.nextTextOnLastStep;
+      }
+
+      return initialNextText;
+    }
+  }, {
     key: 'isLastStep',
     value: function isLastStep() {
       return this.props.steps.length - 1 === this.state.compState;

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,11 @@ export default class StepZilla extends Component {
     super(props);
 
     this.state = {
-      showPreviousBtn: false,
+      showPreviousBtn: this.shouldShowPrevBtnOnStart(),
       showNextBtn: true,
       compState: this.props.startAtStep,
       navState: this.getNavStates(0, this.props.steps.length),
-      nextStepText: 'Next'
+      nextStepText: this.initialNextBtnText()
     };
 
     this.hidden = {
@@ -21,6 +21,20 @@ export default class StepZilla extends Component {
     this.nextClassName = this.props.nextClassName || 'btn btn-next btn-primary btn-lg pull-right';
 
     this.applyValidationFlagsToSteps();
+  }
+
+  shouldShowPrevBtnOnStart() {
+    return !!this.props.startAtStep && this.props.startAtStep > 0;
+  }
+
+  initialNextBtnText() {
+    let initialNextText = 'Next';
+
+    if (this.props.startAtStep === this.props.steps.length - 1 && !!this.props.nextTextOnLastStep) {
+      initialNextText = this.props.nextTextOnLastStep;
+    }
+
+    return initialNextText;
   }
 
   isLastStep() {
@@ -203,7 +217,7 @@ export default class StepZilla extends Component {
           if (this.props.onAfterStep) {
             this.props.onAfterStep();
           }
-          
+
           this.setNavState(this.state.compState + 1);
         }
       })


### PR DESCRIPTION
Currently on production, if you start the modal flow at the Review step (needed for pre-filled positions), the navigation buttons would be in a weird state:

1) The previous button wouldn't show
2) The 'Save Position' button would say 'Next'

We don't want either of these things.  1) Because we want employers to be able to navigate back and edit any params that seem wrong and 2) Because there is no 'Next' step when starting at the final step.

The reason this was happening is that `react-stepzilla` wasn't taking into account the `startAtStep` prop when setting the initialState of `showPrevBtn` and `nextStepText`.

Updating the react-stepzilla source code to correct that

Starting from step 1:
![image](https://user-images.githubusercontent.com/9393597/37995458-68b79c90-31c9-11e8-88a4-951e329b3760.png)

Starting from final step:
![image](https://user-images.githubusercontent.com/9393597/37995490-80b452de-31c9-11e8-8b78-6777d685205c.png)

bot review me @evanmarks 
